### PR TITLE
Move datasets to delete first in line

### DIFF
--- a/ckanext/spatial/harvesters/waf.py
+++ b/ckanext/spatial/harvesters/waf.py
@@ -138,6 +138,19 @@ class WAFHarvester(SpatialHarvester, SingletonPlugin):
 
 
         ids = []
+        for location in delete:
+            obj = HarvestObject(job=harvest_job,
+                                extras=create_extras('','', 'delete'),
+                                guid=url_to_ids[location][0],
+                                package_id=url_to_ids[location][1],
+                               )
+            model.Session.query(HarvestObject).\
+                  filter_by(guid=url_to_ids[location][0]).\
+                  update({'current': False}, False)
+
+            obj.save()
+            ids.append(obj.id)
+
         for location in new:
             guid=hashlib.md5(location.encode('utf8','ignore')).hexdigest()
             obj = HarvestObject(job=harvest_job,
@@ -157,19 +170,6 @@ class WAFHarvester(SpatialHarvester, SingletonPlugin):
                                 guid=url_to_ids[location][0],
                                 package_id=url_to_ids[location][1],
                                )
-            obj.save()
-            ids.append(obj.id)
-
-        for location in delete:
-            obj = HarvestObject(job=harvest_job,
-                                extras=create_extras('','', 'delete'),
-                                guid=url_to_ids[location][0],
-                                package_id=url_to_ids[location][1],
-                               )
-            model.Session.query(HarvestObject).\
-                  filter_by(guid=url_to_ids[location][0]).\
-                  update({'current': False}, False)
-
             obj.save()
             ids.append(obj.id)
 


### PR DESCRIPTION
We have reports of datasets that get re-harvested with an extra `1` in the URL. We have confirmed these reports.
It seems the harvest is doing the best it can to diagnose if this is a new dataset or not; but still failing in some circumstances.
This probably won't fix the bug; however it will mitigate it. By hopefully running through the datasets removal first, if the spatial harvester is essentially doing a "delete and add" when it should be replacing, then the name of the new dataset won't collide with the one that is marked for deleted but still in the system.