### PR TITLE
fix the issue for deleting dataset with empty package_id

### DIFF
--- a/ckanext/spatial/harvesters/base.py
+++ b/ckanext/spatial/harvesters/base.py
@@ -531,10 +531,14 @@ class SpatialHarvester(HarvesterBase):
             context.update({
                 'ignore_auth': True,
             })
-            p.toolkit.get_action('package_delete')(context, {'id': harvest_object.package_id})
-            log.info('Deleted package {0} with guid {1}'.format(harvest_object.package_id, harvest_object.guid))
-
-            return True
+            if harvest_object.package_id:
+                p.toolkit.get_action('package_delete')(context, {'id': harvest_object.package_id})
+                log.info('Deleted package {0} with guid {1}'.format(harvest_object.package_id, harvest_object.guid))
+                return True
+            else:
+                log.info('package_id not found with guid {0}'.format(harvest_object.guid))
+                self._save_object_error('Deleting package failed', harvest_object, 'Import')
+                return False
 
         # Check if it is a non ISO document
         original_document = self._get_object_extra(harvest_object, 'original_document')

--- a/ckanext/spatial/harvesters/base.py
+++ b/ckanext/spatial/harvesters/base.py
@@ -531,14 +531,10 @@ class SpatialHarvester(HarvesterBase):
             context.update({
                 'ignore_auth': True,
             })
-            if harvest_object.package_id:
-                p.toolkit.get_action('package_delete')(context, {'id': harvest_object.package_id})
-                log.info('Deleted package {0} with guid {1}'.format(harvest_object.package_id, harvest_object.guid))
-                return True
-            else:
-                log.info('package_id not found with guid {0}'.format(harvest_object.guid))
-                self._save_object_error('Deleting package failed', harvest_object, 'Import')
-                return False
+            p.toolkit.get_action('package_delete')(context, {'id': harvest_object.package_id})
+            log.info('Deleted package {0} with guid {1}'.format(harvest_object.package_id, harvest_object.guid))
+
+            return True
 
         # Check if it is a non ISO document
         original_document = self._get_object_extra(harvest_object, 'original_document')

--- a/ckanext/spatial/harvesters/waf.py
+++ b/ckanext/spatial/harvesters/waf.py
@@ -156,17 +156,19 @@ class WAFHarvester(SpatialHarvester, SingletonPlugin):
             ids.append(obj.id)
 
         for location in delete:
-            obj = HarvestObject(job=harvest_job,
-                                extras=create_extras('','', 'delete'),
-                                guid=url_to_ids[location][0],
-                                package_id=url_to_ids[location][1],
-                               )
-            model.Session.query(HarvestObject).\
-                  filter_by(guid=url_to_ids[location][0]).\
-                  update({'current': False}, False)
+            # build id list only when package_id is not NULL
+            if url_to_ids[location][1]:
+                obj = HarvestObject(job=harvest_job,
+                                    extras=create_extras('','', 'delete'),
+                                    guid=url_to_ids[location][0],
+                                    package_id=url_to_ids[location][1],
+                                )
+                model.Session.query(HarvestObject).\
+                    filter_by(guid=url_to_ids[location][0]).\
+                    update({'current': False}, False)
 
-            obj.save()
-            ids.append(obj.id)
+                obj.save()
+                ids.append(obj.id)
 
         if len(ids) > 0:
             log.debug('{0} objects sent to the next stage: {1} new, {2} change, {3} delete'.format(


### PR DESCRIPTION
Related [catalog-fetch cannot delete dataset?#4419](https://github.com/GSA/data.gov/issues/4419)

Added a check for package_id before deleting the dataset, run the delete only when package_id is not null, otherwise report an error. 